### PR TITLE
parameters: Add version v2

### DIFF
--- a/bbn-test-4/parameters/global-params.json
+++ b/bbn-test-4/parameters/global-params.json
@@ -49,6 +49,31 @@
       "max_staking_time": 64000,
       "min_staking_time": 64000,
       "confirmation_depth": 10
+    },
+    {
+      "version": 2,
+      "activation_height": 200665,
+      "cap_height": 201385,
+      "tag": "62627434",
+      "covenant_pks": [
+        "03fa9d882d45f4060bdb8042183828cd87544f1ea997380e586cab77d5fd698737",
+        "020aee0509b16db71c999238a4827db945526859b13c95487ab46725357c9a9f25",
+        "0217921cf156ccb4e73d428f996ed11b245313e37e27c978ac4d2cc21eca4672e4",
+        "02113c3a32a9d320b72190a04a020a0db3976ef36972673258e9a38a364f3dc3b0",
+        "0379a71ffd71c503ef2e2f91bccfc8fcda7946f4653cef0d9f3dde20795ef3b9f0",
+        "023bb93dfc8b61887d771f3630e9a63e97cbafcfcc78556a474df83a31a0ef899c",
+        "03d21faf78c6751a0d38e6bd8028b907ff07e9a869a43fc837d6b3f8dff6119a36",
+        "0340afaf47c4ffa56de86410d8e47baa2bb6f04b604f4ea24323737ddc3fe092df",
+        "03f5199efae3f28bb82476163a7e458c7ad445d9bffb0682d10d3bdb2cb41f8e8e"
+      ],
+      "covenant_quorum": 6,
+      "unbonding_time": 1008,
+      "unbonding_fee": 10000,
+      "max_staking_amount": 5000000,
+      "min_staking_amount": 50000,
+      "max_staking_time": 64000,
+      "min_staking_time": 64000,
+      "confirmation_depth": 10
     }
   ]
 }


### PR DESCRIPTION
Version v2 comes with the following updates: 
- Activation height: 200665 (~Wed 19/06 9AM UTC)
- Time-based cap: Staking will be open for **720 BTC blocks**, up to height 201385
- 2 Babylon Covenant Signer BTC PKs are rotated