### PR TITLE
Typo Update README.md

### DIFF
--- a/bbn-test-4/finality-providers/README.md
+++ b/bbn-test-4/finality-providers/README.md
@@ -232,7 +232,7 @@ Properties descriptions:
 - `security_contact`: required email for security contact.
 - `details`: any other optional detail information.
 - `btc_pk`: the btc pub key as hex.
-- `commision`: the commission charged from btc stakers rewards.
+- `commission`: the commission charged from btc stakers rewards.
 Comission will be parsed as `sdk.Dec`:
   - `"1.00"` represents 100% commission.
   - `"0.10"` represents  10% commission.


### PR DESCRIPTION
<img width="516" alt="Снимок экрана 2024-11-10 в 15 56 26" src="https://github.com/user-attachments/assets/016f61da-846a-4f80-b456-6885f9de56b5">

The word "commision" should be corrected to "**commission**".

Corrected.